### PR TITLE
Increase lint action timeout

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.52
+          args: --timeout=5m
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The GH action for lint keeps constantly timing out - try increasing the time out.