### PR TITLE
Make skipping log message more clear

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,11 @@ func enhanceRecordData(
 
 							asc := associator.NewAssociator(svc.DimensionRegexps, resourceCache[cwm.Namespace])
 							r, skip := asc.AssociateMetricToResource(cwm)
-							if r == nil || skip {
+							if r == nil {
+								logger.Debug("No matching resource found, skipping tags enrichment", "namespace", cwm.Namespace, "metric", cwm.MetricName)
+								continue
+							}
+							if skip {
 								logger.Debug("Could not associate any resource, skipping tags enrichment", "namespace", cwm.Namespace, "metric", cwm.MetricName)
 								continue
 							}


### PR DESCRIPTION
Differentiate between not found and skip enriching in debug log message, to make the reason for skipping more obvious to user.