### PR TITLE
Add new associator algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ There is a couple of configuration options that can be set via environment varia
 | Environment variable             | Default |Possible values   | Description   |
 |----------------------------------|---------|------------------|---------------|
 | `LOG_LEVEL`                      | `info`  | `debug`          | Sets log level.
+| `USE_NEW_ASSOCIATOR`             | `true`  | `false`          | Determines whether Lambda should fall back to the old associator algorithm. Be default Lambda uses the "max dimensions" associator. For more details see [here](https://github.com/nerdswords/yet-another-cloudwatch-exporter/blob/master/docs/feature_flags.md#new-associator-algorithm).
 | `CONTINUE_ON_RESOURCE_FAILURE`   | `true`  | `false`          | Determines whether to continue on a failed API call to obtain resources. If set to true (by default), the Lambda will skip enriching the metrics with tags and return metrics without tags. If set to false, the Lambda will terminate and the metrics won't be exported to Kinesis Data Firehose.
 | `FILE_CACHE_ENABLED`             | `true`  | `false`          | Enables caching of resources to local file. See [Caching resources](###caching-resources) for more details.
 | `FILE_CACHE_PATH`                | `/tmp`  | <file_path>      | Sets the path to directory where to cache resources. See [Caching resources](###caching-resources) for more details.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ There is a couple of configuration options that can be set via environment varia
 | Environment variable             | Default |Possible values   | Description   |
 |----------------------------------|---------|------------------|---------------|
 | `LOG_LEVEL`                      | `info`  | `debug`          | Sets log level.
-| `USE_NEW_ASSOCIATOR`             | `true`  | `false`          | Determines whether Lambda should fall back to the old associator algorithm. Be default Lambda uses the "max dimensions" associator. For more details see [here](https://github.com/nerdswords/yet-another-cloudwatch-exporter/blob/master/docs/feature_flags.md#new-associator-algorithm).
 | `CONTINUE_ON_RESOURCE_FAILURE`   | `true`  | `false`          | Determines whether to continue on a failed API call to obtain resources. If set to true (by default), the Lambda will skip enriching the metrics with tags and return metrics without tags. If set to false, the Lambda will terminate and the metrics won't be exported to Kinesis Data Firehose.
 | `FILE_CACHE_ENABLED`             | `true`  | `false`          | Enables caching of resources to local file. See [Caching resources](###caching-resources) for more details.
-| `FILE_CACHE_PATH`                | `/tmp`  | <file_path>      | Sets the path to directory where to cache resources. See [Caching resources](###caching-resources) for more details.
-| `FILE_CACHE_EXPIRATION`          | `1h`    | <duration>       | Sets the expiration time for the cached resources. See [Caching resources](###caching-resources) for more details.
+| `FILE_CACHE_PATH`                | `/tmp`  | `<file_path>`    | Sets the path to directory where to cache resources. See [Caching resources](###caching-resources) for more details.
+| `FILE_CACHE_EXPIRATION`          | `1h`    | `<duration>`     | Sets the expiration time for the cached resources. See [Caching resources](###caching-resources) for more details.
 
 ### Necessary permissions
 The Lambda will use it's [execution role](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html) to call other AWS APIs. You need to therefore ensure your Lambda's role has following permissions. You can use the following JSON to create an inline policy for your role, to grant all necessary permissions:

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.43.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	clientsv2 "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/v2"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job/associator"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job/maxdimassociator"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	metricsservicepb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
@@ -30,6 +31,12 @@ import (
 
 const cacheFile = "cache"
 
+// resoureAssociator is an interface used for associator. This is used in place
+// of the upstream interface which is not exported.
+type resourceAssociator interface {
+	AssociateMetricToResource(cwMetric *model.Metric) (*model.TaggedResource, bool)
+}
+
 func main() {
 	lambda.Start(lambdaHandler)
 }
@@ -40,6 +47,7 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 		region = aws.String(os.Getenv("AWS_REGION"))
 
 		// Set defaults and if the env var is set, override the default value.
+		useNewAssociator          = true
 		continueOnResourceFailure = true
 		fileCacheEnabled          = true
 		fileCacheExpiration       = 1 * time.Hour
@@ -56,6 +64,10 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 
 	if os.Getenv("FILE_CACHE_ENABLED") == "false" {
 		fileCacheEnabled = false
+	}
+
+	if os.Getenv("USE_NEW_ASSOCIATOR") == "false" {
+		useNewAssociator = false
 	}
 
 	if os.Getenv("FILE_CACHE_EXPIRATION") != "" {
@@ -94,7 +106,7 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	clientTag := cache.GetTaggingClient(*region, config.Role{}, 5)
 
 	for _, record := range request.Records {
-		newData, err := enhanceRecordData(logger, fileCachePath, continueOnResourceFailure, record.Data, resourcesPerNamespace, region, clientTag, fileCacheExpiration, fileCacheEnabled)
+		newData, err := enhanceRecordData(logger, fileCachePath, continueOnResourceFailure, useNewAssociator, record.Data, resourcesPerNamespace, region, clientTag, fileCacheExpiration, fileCacheEnabled)
 		if err != nil {
 			logger.Error(err, "Failed to enhance record data")
 			return nil, err
@@ -194,6 +206,7 @@ func enhanceRecordData(
 	logger logging.Logger,
 	fileCachePath string,
 	continueOnResourceFailure bool,
+	useNewAssociator bool,
 	data []byte,
 	resourceCache map[string][]*model.TaggedResource,
 	region *string,
@@ -240,7 +253,13 @@ func enhanceRecordData(
 								resourceCache[cwm.Namespace] = resources
 							}
 
-							asc := associator.NewAssociator(svc.DimensionRegexps, resourceCache[cwm.Namespace])
+							var asc resourceAssociator
+							if useNewAssociator {
+								asc = maxdimassociator.NewAssociator(svc.DimensionRegexps, resourceCache[cwm.Namespace])
+							} else {
+								asc = associator.NewAssociator(svc.DimensionRegexps, resourceCache[cwm.Namespace])
+							}
+
 							r, skip := asc.AssociateMetricToResource(cwm)
 							if r == nil {
 								logger.Debug("No matching resource found, skipping tags enrichment", "namespace", cwm.Namespace, "metric", cwm.MetricName)

--- a/main_test.go
+++ b/main_test.go
@@ -298,7 +298,7 @@ func Test_enhanceRecordData(t *testing.T) {
 				t.Fatalf("failed to create test data: %v", err)
 			}
 
-			got, err := enhanceRecordData(l, "", tt.continueOnResourceFailure, true, data, mockCache, aws.String("us-east-1"), mockClient, 1*time.Hour, false)
+			got, err := enhanceRecordData(l, "", tt.continueOnResourceFailure, data, mockCache, aws.String("us-east-1"), mockClient, 1*time.Hour, false)
 			if err != tt.wantErr && tt.wantErr != tagging.ErrExpectedToFindResources {
 				t.Errorf("enhanceRecordData() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/main_test.go
+++ b/main_test.go
@@ -298,7 +298,7 @@ func Test_enhanceRecordData(t *testing.T) {
 				t.Fatalf("failed to create test data: %v", err)
 			}
 
-			got, err := enhanceRecordData(l, "", tt.continueOnResourceFailure, data, mockCache, aws.String("us-east-1"), mockClient, 1*time.Hour, false)
+			got, err := enhanceRecordData(l, "", tt.continueOnResourceFailure, true, data, mockCache, aws.String("us-east-1"), mockClient, 1*time.Hour, false)
 			if err != tt.wantErr && tt.wantErr != tagging.ErrExpectedToFindResources {
 				t.Errorf("enhanceRecordData() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Resolves [ES-86](https://coralogix.atlassian.net/browse/ES-86)

Changes the Lambda to use the "max dimensions" associator that should improve results for associating resources to tags (see https://github.com/nerdswords/yet-another-cloudwatch-exporter/blob/master/docs/feature_flags.md#new-associator-algorithm).

[ES-86]: https://coralogix.atlassian.net/browse/ES-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ