### PR TITLE
Migrate to custom runtime

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,4 +38,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          files: function.zip
+          files: bootstrap.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 function
+bootstrap

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ If you'd like to contribute to our code or documentation, the best way to go abo
 We require all of our commits to be signed, please make sure they are signed by following [this guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 1. Before opening a PR, ensure all checks (formatting, lint, tests) are passing locally by running the `make package` target.
-2. Optionally, if you'd like to check the functionality of your changes, you can run a manual test on your own AWS account - the resulting `function.zip` afer running `make package` can be used for upload and testing.
+2. Optionally, if you'd like to check the functionality of your changes, you can run a manual test on your own AWS account - the resulting `bootstrap.zip` afer running `make package` can be used for upload and testing.
 3. If you're PR is not ready for a review yet, please mark it as a draft.
 4. Reviewers will get to your PR as soon as possible. In order for your PR to be merged, all substantial comments must be addressed and at least **1** approval from a repository owner is required.
 
@@ -32,5 +32,5 @@ For each new version a GitHub release is created. To prepare a new release, foll
    git push origin "v${tag}"
 ```
 4. GitHub action will automatically create a new _draft_ release after running all the required CI jobs.
-5. Once the draft release is created, go to [Releases](https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/releases) page and open the new draft release. Edit the release notes as needed and double check that the `function.zip` file is attached to the release.
+5. Once the draft release is created, go to [Releases](https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/releases) page and open the new draft release. Edit the release notes as needed and double check that the `bootstrap.zip` file is attached to the release.
 6. Once everything is ready, publish the release.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-BINARY_FILE_NAME ?= "function"
-ZIP_FILE_NAME ?= "function.zip"
+BINARY_FILE_NAME ?= "bootstrap"
+ZIP_FILE_NAME ?= "bootstrap.zip"
 ## By default, build for Linux on amd64, as that's the Lambda architecture we'll be using.
-ARCH ?= "amd64"
+ARCH ?= "arm64"
 OS ?= "linux"
 
 ## The final bucket name will consist of BUCKET_BASE_NAME and the region name, in format <BUCKET_BASE_NAME>-<region>.

--- a/README.md
+++ b/README.md
@@ -9,18 +9,21 @@ This Lambda function can be used as a Kinesis Firehose transformation function, 
 - Returns Kinesis Firehose response with transformed record in OTLP v0.7, size-delimited format, for further processing and exporting to Coralogix (or other) destination by the Kinesis stream
 
 ### Installation and usage
-1. Download the `function.zip` file from the [releases](https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/releases) page. Unless instructed otherwise, we recommend downloading the latest release. Alterantively, you can test, lint and build the zipped Lambda function by yourself by running `make all`.
+1. Download the `bootstrap.zip` file from the [releases](https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/releases) page. Unless instructed otherwise, we recommend downloading the latest release. Alterantively, you can test, lint and build the zipped Lambda function by yourself by running `make all`.
 2. Create a new AWS Lambda function in your designated region with the following parameters:
-    - Runtime: `Go 1.x`
-    - Handler: `function`
-    - Architecture: `x86_64` (but you can also build the function for `arm64`)
-3. Upload the `function.zip` file as the code source.
+    - Runtime: `Custom runtime on Amazon Linux 2`
+    - Handler: `bootstrap`
+    - Architecture: `arm64` (but you can also build the function for `x86_64`)
+3. Upload the `bootstrap.zip` file as the code source.
 4. Make sure to set the memory. We recommend starting with `128 MB` and, depending on the number of metrics you export and speed of Lambda processinr, see if you need to increase it.
 5. Adjust the role of the Lambda function as described below in section [Necessary permissions](###necessary-permissions).
 6. Optionally, add environment variables to configure the Lambda, as described in the [Configuration](###configuration) section.
 7. The Lambda function is ready to be used as in [Kinesis Data Firehose Data Transformation](https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html?icmpid=docs_console_unmapped). Please note the function ARN and provide it in the relevant section of the Kinesis Data Firehose configuration.
 
 Depending on the size of your setup, we also recommend to accordingly adjust your Lambda [buffer hint](https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html) and Kinesis Data Firehose [buffer size](https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#frequency) configuration. For most optimal experience, we recommend setting the Lambda buffer hint to `0.2 MB` and Kinsis Data Firehose buffer size to `1 MB`. **Beware that this might cause more frequent Lambda runs, which might result in higher costs**.
+
+## Migrating from `Go 1.x` runtime to custom runtime on Amazon Linux 2
+Please beware that the `Go 1.x` runtime will be [deprecated](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) at the end of December 2023. If you were previously using this Lambda function with the `Go 1.x`, you will need to migrate the function in accordance with the instructions in the [AWS documentation](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/).
 
 ### Configuration
 There is a couple of configuration options that can be set via environment variables:


### PR DESCRIPTION
Part of https://coralogix.atlassian.net/browse/ES-123

Due to the planned deprecation of the `Go 1.x` Lambda runtime (see https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/), we are migrating the Lambda function to work with the custom runtime based on Amazon Linux 2 (`provided.al2`) as advised. This also requires some changes to our build process, namely naming to `bootstrap` instead of `function` and changing the architecture to `arm64`.

This has been tested manually.