### PR TITLE
Publish dev also on changes to `go.mod` and `Makefile`

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - '**.go'
+      - 'go.mod'
+      - 'Makefile'
 
 env:
   BUCKET_BASE_NAME: ${{ vars.BUCKET_BASE_NAME }}


### PR DESCRIPTION
Currently we publish only on changes to `*.go` files but we also might want to publish on other related changes.