### PR TITLE
Support adding static labels to metrics firehose

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	if os.Getenv("STATIC_LABELS") != "" {
 		staticLabelsEnv := os.Getenv("STATIC_LABELS")
 		var staticLabelsJSON []string
-		err := json.Unmarshal([]byte(staticLabelsEnv), &staticLabels)
+		err := json.Unmarshal([]byte(staticLabelsEnv), &staticLabelsJSON)
 		if err != nil {
 			logger.Error(err, "Failed to parse JSON string from STATIC_LABELS")
 		} else {


### PR DESCRIPTION
This is intended to match the functionality provided by the StaticLabels parameter of the aws-metrics-collector

Ref: https://coralogix.com/docs/developer-portal/infrastructure-as-code/terraform-provider/integrations/aws-metrics-collector/

It is intended to go along with https://github.com/coralogix/terraform-coralogix-aws/pull/272