### PR TITLE
CDS-2628 - tags enrichment for cross-account observability

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @coralogix/team-ido

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @coralogix/team-ido
+* 

--- a/README.md
+++ b/README.md
@@ -161,10 +161,12 @@ And the following **permissions policy** to allow read-only access to resource t
 ### How It Works
 
 1. The Lambda extracts `cloud.account.id` from each OTLP metric record
-2. If the source account differs from the monitoring account, it assumes the corresponding role from `CROSS_ACCOUNT_ROLES` via STS
+2. If the source account differs from the monitoring account, the Lambda looks up that account ID in `CROSS_ACCOUNT_ROLES` and calls AWS STS `AssumeRole` on the mapped role ARN
 3. Using the temporary credentials, it calls `tag:GetResources` in the linked account to fetch resource tags
 4. Tags are associated with the metrics and added as labels before delivery to Coralogix
 5. Results are cached per account per namespace to avoid redundant API calls and prevent data contamination between accounts
+
+If no mapping exists for a source account ID, the Lambda falls back to default credentials and cross-account tags for that account may be missing.
 
 ## Extra costs and usage of AWS APIs
 There are couple of costs connected with usage of Lambda transformation. Below, these costs are described in details (based on examples and pricing in the US East region). This example assumes a user will be exporting metrics from all namespaces and that the metrics updates are coming once per minute (which is not true for all AWS metrics, see [this thread](https://serverfault.com/questions/1003344/aws-cloudwatch-metrics-are-there-convergence-delays?newreg=80710344c54e4a8397eac3acfdb01941) to learn more). The example is based on a region with ~5000 metrics. For detailed pricing information see [here](https://aws.amazon.com/lambda/pricing/). This calculation is for informative purposes and it is valid as of March 2023 to the best of our knowledge.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install it automatically, you have a choice of 3 options:
 ### Manual Installation
 1. Download the `bootstrap.zip` file from the [releases](https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/releases) page. Unless instructed otherwise, we recommend downloading the latest release. Alternatively, you can test, lint and build the zipped Lambda function by yourself by running `make package`.
 2. Create a new AWS Lambda function in your designated region with the following parameters:
-    - Runtime: `Custom runtime on Amazon Linux 2`
+    - Runtime: `Custom runtime on Amazon Linux 2023 (provided.al2023)`
     - Handler: `bootstrap`
     - Architecture: `arm64` (but you can also build the function for `x86_64`)
 3. Upload the `bootstrap.zip` file as the code source.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ To install it automatically, you have a choice of 3 options:
 3. [Terraform Module](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/firehose-metrics)
 
 ### Manual Installation
-1. Download the `bootstrap.zip` file from the [releases](https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/releases) page. Unless instructed otherwise, we recommend downloading the latest release. Alterantively, you can test, lint and build the zipped Lambda function by yourself by running `make all`.
+1. Download the `bootstrap.zip` file from the [releases](https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/releases) page. Unless instructed otherwise, we recommend downloading the latest release. Alternatively, you can test, lint and build the zipped Lambda function by yourself by running `make package`.
 2. Create a new AWS Lambda function in your designated region with the following parameters:
     - Runtime: `Custom runtime on Amazon Linux 2`
     - Handler: `bootstrap`
     - Architecture: `arm64` (but you can also build the function for `x86_64`)
 3. Upload the `bootstrap.zip` file as the code source.
-4. Make sure to set the memory. We recommend starting with `128 MB` and, depending on the number of metrics you export and speed of Lambda processinr, see if you need to increase it.
-5. Adjust the role of the Lambda function as described below in section [Necessary permissions](###necessary-permissions).
-6. Optionally, add environment variables to configure the Lambda, as described in the [Configuration](###configuration) section.
+4. Make sure to set the memory. We recommend starting with `128 MB` and, depending on the number of metrics you export and speed of Lambda processing, see if you need to increase it.
+5. Adjust the role of the Lambda function as described below in section [Necessary permissions](#necessary-permissions).
+6. Optionally, add environment variables to configure the Lambda, as described in the [Configuration](#configuration) section.
 7. The Lambda function is ready to be used as in [Amazon Data Firehose Data Transformation](https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html?icmpid=docs_console_unmapped). Please note the function ARN and provide it in the relevant section of the Amazon Data Firehose configuration.
 
-Depending on the size of your setup, we also recommend to accordingly adjust your Lambda [buffer hint](https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html) and Amazon Data Firehose [buffer size](https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#frequency) configuration. For most optimal experience, we recommend setting the Lambda buffer hint to `0.2 MB` and Kinsis Data Firehose buffer size to `1 MB`. **Beware that this might cause more frequent Lambda runs, which might result in higher costs**.
+Depending on the size of your setup, we also recommend to accordingly adjust your Lambda [buffer hint](https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html) and Amazon Data Firehose [buffer size](https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html#frequency) configuration. For most optimal experience, we recommend setting the Lambda buffer hint to `0.2 MB` and Kinesis Data Firehose buffer size to `1 MB`. **Beware that this might cause more frequent Lambda runs, which might result in higher costs**.
 
 ## Migrating from `Go 1.x` runtime to custom runtime on Amazon Linux 2
 Please beware that the `Go 1.x` runtime will be [deprecated](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) at the end of December 2023. If you were previously using this Lambda function with the `Go 1.x`, you will need to migrate the function in accordance with the instructions in the [AWS documentation](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/).
@@ -42,14 +42,16 @@ There is a couple of configuration options that can be set via environment varia
 |----------------------------------|---------|------------------|---------------|
 | `LOG_LEVEL`                      | `info`  | `debug`          | Sets log level.
 | `CONTINUE_ON_RESOURCE_FAILURE`   | `true`  | `false`          | Determines whether to continue on a failed API call to obtain resources. If set to true (by default), the Lambda will skip enriching the metrics with tags and return metrics without tags. If set to false, the Lambda will terminate and the metrics won't be exported to Amazon Data Firehose.
-| `FILE_CACHE_ENABLED`             | `true`  | `false`          | Enables caching of resources to local file. See [Caching resources](###caching-resources) for more details.
-| `FILE_CACHE_PATH`                | `/tmp`  | `<file_path>`    | Sets the path to directory where to cache resources. See [Caching resources](###caching-resources) for more details.
-| `FILE_CACHE_EXPIRATION`          | `1h`    | `<duration>`     | Sets the expiration time for the cached resources. See [Caching resources](###caching-resources) for more details.
+| `FILE_CACHE_ENABLED`             | `true`  | `false`          | Enables caching of resources to local file. See [Caching resources](#caching-resources) for more details.
+| `FILE_CACHE_PATH`                | `/tmp`  | `<file_path>`    | Sets the path to directory where to cache resources. The directory must already exist. See [Caching resources](#caching-resources) for more details.
+| `FILE_CACHE_EXPIRATION`          | `1h`    | `<duration>`     | Sets the expiration time for the cached resources. See [Caching resources](#caching-resources) for more details.
 | `STATIC_LABELS`                  |         | `<json_array>`   | JSON array of key=value pairs to add as static labels to metrics. Example: `["env=production","team=platform"]`.
 | `DEFAULT_LABELS`                 | `false` | `true`           | When enabled, static labels are added to all metrics even if resource tags cannot be resolved. Acts as a fallback mechanism for consistent labeling across all metrics.
+| `CROSS_ACCOUNT_ENABLED`          | `false` | `true`           | Enables cross-account tag enrichment for metrics from linked accounts via AWS OAM. See [Cross-Account Tag Enrichment](#cross-account-tag-enrichment) for more details.
+| `CROSS_ACCOUNT_ROLES`            |         | `<json_object>`  | JSON map of linked account IDs to IAM role ARNs to assume for tag enrichment. Example: `{"123456789012":"arn:aws:iam::123456789012:role/CoralogixMetricsReader"}`. Required when `CROSS_ACCOUNT_ENABLED=true`.
 
 ### Necessary permissions
-The Lambda will use it's [execution role](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html) to call other AWS APIs. You need to therefore ensure your Lambda's role has following permissions. You can use the following JSON to create an inline policy for your role, to grant all necessary permissions:
+The Lambda will use its [execution role](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html) to call other AWS APIs. You need to therefore ensure your Lambda's role has following permissions. You can use the following JSON to create an inline policy for your role, to grant all necessary permissions:
 ```
 {
   "Version": "2012-10-17",
@@ -67,6 +69,7 @@ The Lambda will use it's [execution role](https://docs.aws.amazon.com/lambda/lat
         "dms:DescribeReplicationTasks",
         "ec2:DescribeTransitGatewayAttachments",
         "ec2:DescribeSpotFleetRequests",
+        "sts:AssumeRole",
         "shield:ListProtections",
         "storagegateway:ListGateways",
         "storagegateway:ListTagsForResource",
@@ -82,11 +85,86 @@ The Lambda will use it's [execution role](https://docs.aws.amazon.com/lambda/lat
 ### Caching resources
 Users, who do not wish to fetch resources from the AWS API on every Lambda invocation, can take advantage of caching of resources to a local file. Caching is enabled by default; to disable it, set the `FILE_CACHE_ENABLED` environment variable to `false`.
 
- This can be especially useful for users with a large number of resources, in order to keep the Lambda invocation time low and at the same to avoid hitting the [resource tagging API](https://aws.amazon.com/blogs/aws/new-aws-resource-tagging-api/) rate limits. Beware though that any changes to resource tags will not be reflect in metrics until the cache expires and is renewed.
+ This can be especially useful for users with a large number of resources, in order to keep the Lambda invocation time low and at the same to avoid hitting the [resource tagging API](https://aws.amazon.com/blogs/aws/new-aws-resource-tagging-api/) rate limits. Beware though that any changes to resource tags will not be reflected in metrics until the cache expires and is renewed.
 
-Caching can be enabled by setting the `FILE_CACHE_PATH` environment variable to a path of the directory, where the resources will be cached. You can leverage Lambda's emphemeral storage by settings this siply to `/tmp`. This ensures that the resources will be cached between Lambda invocations on a single Lambda environment, meaning the cache will be reset when new Lambda environment is created. For more details on ephemeral storage and other storage options see [here](https://aws.amazon.com/blogs/compute/choosing-between-aws-lambda-data-storage-options-in-web-apps/).
+Caching can be enabled by setting the `FILE_CACHE_PATH` environment variable to a path of the directory, where the resources will be cached. You can leverage Lambda's ephemeral storage by setting this simply to `/tmp`. This ensures that the resources will be cached between Lambda invocations on a single Lambda environment, meaning the cache will be reset when new Lambda environment is created. For more details on ephemeral storage and other storage options see [here](https://aws.amazon.com/blogs/compute/choosing-between-aws-lambda-data-storage-options-in-web-apps/).
 
 The resources will be cached for a period of time, which can be set by the `FILE_CACHE_EXPIRATION` environment variable. The expiration time can be set in the [Go duration format](https://golang.org/pkg/time/#ParseDuration). If the `FILE_CACHE_EXPIRATION` is not set, the resources will be cached for 1 hour by default.
+
+## Cross-Account Tag Enrichment
+
+When using [AWS CloudWatch Cross-Account Observability (OAM)](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html), metrics from multiple linked accounts flow into a central monitoring account. The Lambda processor can enrich those cross-account metrics with resource-level tags (e.g., EC2 instance tags, EKS cluster tags, RDS tags) by assuming IAM roles in the linked accounts.
+
+This feature is **opt-in and disabled by default**. To enable it, set `CROSS_ACCOUNT_ENABLED=true` and configure `CROSS_ACCOUNT_ROLES` with a JSON map of account IDs to IAM role ARNs.
+
+> **Prerequisite:** The CloudWatch Metric Stream in the monitoring account must have `include_linked_accounts_metrics` enabled. This causes OTLP records to carry the `cloud.account.id` resource attribute, which the Lambda uses to identify the source account of each metric.
+
+### IAM Setup
+
+Two sets of IAM changes are required:
+
+#### 1. Monitoring Account — Lambda Execution Role
+
+Add `sts:AssumeRole` permission so the Lambda can assume roles in linked accounts:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "sts:AssumeRole",
+    "Resource": "arn:aws:iam::*:role/CoralogixMetricsReader"
+  }]
+}
+```
+
+#### 2. Each Linked Account — Create a Cross-Account Role
+
+Create an IAM role (e.g., `CoralogixMetricsReader`) with the following **trust policy**, replacing `MONITORING_ACCOUNT_ID` and the Lambda role name as appropriate:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "AWS": "arn:aws:iam::MONITORING_ACCOUNT_ID:role/YOUR_LAMBDA_EXECUTION_ROLE_NAME"
+    },
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+And the following **permissions policy** to allow read-only access to resource tags and descriptions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "tag:GetResources",
+      "ec2:Describe*",
+      "rds:Describe*",
+      "lambda:List*",
+      "lambda:GetFunction",
+      "eks:DescribeCluster",
+      "eks:ListClusters",
+      "elasticloadbalancing:Describe*",
+      "autoscaling:Describe*"
+    ],
+    "Resource": "*"
+  }]
+}
+```
+
+### How It Works
+
+1. The Lambda extracts `cloud.account.id` from each OTLP metric record
+2. If the source account differs from the monitoring account, it assumes the corresponding role from `CROSS_ACCOUNT_ROLES` via STS
+3. Using the temporary credentials, it calls `tag:GetResources` in the linked account to fetch resource tags
+4. Tags are associated with the metrics and added as labels before delivery to Coralogix
+5. Results are cached per account per namespace to avoid redundant API calls and prevent data contamination between accounts
 
 ## Extra costs and usage of AWS APIs
 There are couple of costs connected with usage of Lambda transformation. Below, these costs are described in details (based on examples and pricing in the US East region). This example assumes a user will be exporting metrics from all namespaces and that the metrics updates are coming once per minute (which is not true for all AWS metrics, see [this thread](https://serverfault.com/questions/1003344/aws-cloudwatch-metrics-are-there-convergence-delays?newreg=80710344c54e4a8397eac3acfdb01941) to learn more). The example is based on a region with ~5000 metrics. For detailed pricing information see [here](https://aws.amazon.com/lambda/pricing/). This calculation is for informative purposes and it is valid as of March 2023 to the best of our knowledge.

--- a/main.go
+++ b/main.go
@@ -168,11 +168,11 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	}, nil
 }
 
-func getOrCacheResourcesToEFS(logger *slog.Logger, client tagging.Client, fileCachePath, namespace, accountID string, region *string, cacheExpiration time.Duration, cacheEnabled bool) ([]*model.TaggedResource, error) {
+func getOrCacheResourcesToEFS(ctx context.Context, logger *slog.Logger, client tagging.Client, fileCachePath, namespace, accountID string, region *string, cacheExpiration time.Duration, cacheEnabled bool) ([]*model.TaggedResource, error) {
 	// If cacheEnabled is false, don't cache.
 	if !cacheEnabled {
 		logger.Info("Cache disabled, fetching resources directly", "namespace", namespace)
-		resources, err := retrieveResources(namespace, region, client)
+		resources, err := retrieveResources(ctx, namespace, region, client)
 		logger.Info("Resources fetched", "namespace", namespace, "count", len(resources), "error", err)
 		return resources, err
 	}
@@ -197,7 +197,7 @@ func getOrCacheResourcesToEFS(logger *slog.Logger, client tagging.Client, fileCa
 
 	if os.IsNotExist(err) || isExpired {
 		logger.Info("Cache not found or expired, retrieving resources", "namespace", namespace, "notExists", os.IsNotExist(err), "isExpired", isExpired)
-		resources, err := retrieveResources(namespace, region, client)
+		resources, err := retrieveResources(ctx, namespace, region, client)
 		logger.Info("Resources retrieved from API", "namespace", namespace, "count", len(resources), "error", err)
 		if err != nil {
 			return nil, err
@@ -235,8 +235,8 @@ func getOrCacheResourcesToEFS(logger *slog.Logger, client tagging.Client, fileCa
 	return resources, nil
 }
 
-func retrieveResources(namespace string, region *string, client tagging.Client) ([]*model.TaggedResource, error) {
-	resources, err := client.GetResources(context.Background(), model.DiscoveryJob{
+func retrieveResources(ctx context.Context, namespace string, region *string, client tagging.Client) ([]*model.TaggedResource, error) {
+	resources, err := client.GetResources(ctx, model.DiscoveryJob{
 		Namespace: namespace,
 	}, *region)
 	if err != nil && err != tagging.ErrExpectedToFindResources {
@@ -316,7 +316,7 @@ func enhanceRecordData(
 									resourceCache[cacheKey] = []*model.TaggedResource{}
 									continue
 								}
-								resources, err := getOrCacheResourcesToEFS(logger, client, fileCachePath, cwm.Namespace, sourceAccountID, region, fileCacheExpiration, fileCacheEnabled)
+								resources, err := getOrCacheResourcesToEFS(ctx, logger, client, fileCachePath, cwm.Namespace, sourceAccountID, region, fileCacheExpiration, fileCacheEnabled)
 								if err != nil && err != tagging.ErrExpectedToFindResources {
 									logger.Error("Failed to get resources for namespace", "namespace", cwm.Namespace, "error", err)
 									if continueOnResourceFailure {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -35,10 +36,12 @@ const cacheFile = "cache"
 
 var (
 	// Cross-account role infrastructure for tag enrichment
-	crossAccountCaches map[string]*clientsv2.CachingFactory // accountID -> cache
-	crossAccountRoles  map[string]string                    // accountID -> roleARN
-	currentAccountID   string
-	cacheMutex         sync.RWMutex
+	crossAccountCaches   map[string]*clientsv2.CachingFactory // accountID - cache
+	crossAccountRoles    map[string]string                    // accountID - roleARN
+	currentAccountID     string
+	crossAccountInitOnce sync.Once
+	crossAccountInitErr  error
+	cacheMutex           sync.RWMutex
 )
 
 func main() {
@@ -66,8 +69,8 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	)
 
 	// Initialize cross-account role infrastructure (once per Lambda container)
-	if crossAccountEnabled && crossAccountCaches == nil {
-		if err := initializeCrossAccountRoles(ctx, logger, *region); err != nil {
+	if crossAccountEnabled {
+		if err := ensureCrossAccountInitialized(ctx, logger, *region); err != nil {
 			logger.Error("Failed to initialize cross-account roles", "error", err)
 			// Continue without cross-account enrichment
 		}
@@ -282,7 +285,7 @@ func enhanceRecordData(
 			}
 
 			if crossAccountEnabled && sourceAccountID != "" && sourceAccountID != currentAccountID {
-				logger.Info("Using cross-account tagging client", "accountID", sourceAccountID)
+				logger.Debug("Using cross-account tagging client", "accountID", sourceAccountID)
 			}
 
 			for _, ilm := range ilms.InstrumentationLibraryMetrics {
@@ -467,6 +470,16 @@ func isCrossAccountEnabled() bool {
 // Cross-Account Tag Enrichment
 // ============================================================================
 
+var accountIDRegex = regexp.MustCompile(`^\d{12}$`)
+
+func ensureCrossAccountInitialized(ctx context.Context, logger *slog.Logger, region string) error {
+	crossAccountInitOnce.Do(func() {
+		crossAccountInitErr = initializeCrossAccountRoles(ctx, logger, region)
+	})
+
+	return crossAccountInitErr
+}
+
 // initializeCrossAccountRoles sets up caches and clients for cross-account tag enrichment
 func initializeCrossAccountRoles(ctx context.Context, logger *slog.Logger, region string) error {
 	cacheMutex.Lock()
@@ -501,11 +514,17 @@ func initializeCrossAccountRoles(ctx context.Context, logger *slog.Logger, regio
 		return nil
 	}
 
-	if err := json.Unmarshal([]byte(crossAccountRolesJSON), &crossAccountRoles); err != nil {
+	validatedRoles, err := parseAndValidateCrossAccountRoles(crossAccountRolesJSON, logger)
+	if err != nil {
 		return fmt.Errorf("failed to parse CROSS_ACCOUNT_ROLES: %w", err)
 	}
+	crossAccountRoles = validatedRoles
 
 	logger.Info("Cross-account roles configured", "accounts", len(crossAccountRoles))
+	if len(crossAccountRoles) == 0 {
+		logger.Warn("CROSS_ACCOUNT_ROLES contains no valid account-role mappings. Cross-account enrichment will use default cache only.")
+		return nil
+	}
 
 	// Initialize cache for each cross-account role
 	for accountID, roleARN := range crossAccountRoles {
@@ -535,6 +554,27 @@ func initializeCrossAccountRoles(ctx context.Context, logger *slog.Logger, regio
 	return nil
 }
 
+func parseAndValidateCrossAccountRoles(raw string, logger *slog.Logger) (map[string]string, error) {
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, err
+	}
+
+	validated := make(map[string]string, len(parsed))
+	for accountID, roleARN := range parsed {
+		switch {
+		case !accountIDRegex.MatchString(accountID):
+			logger.Warn("Ignoring invalid cross-account role mapping with malformed account ID", "accountID", accountID)
+		case strings.TrimSpace(roleARN) == "":
+			logger.Warn("Ignoring invalid cross-account role mapping with empty role ARN", "accountID", accountID)
+		default:
+			validated[accountID] = roleARN
+		}
+	}
+
+	return validated, nil
+}
+
 // getTaggingClientForAccount returns the appropriate tagging client for the given account
 func getTaggingClientForAccount(accountID, region string, logger *slog.Logger, defaultCache *clientsv2.CachingFactory, crossAccountEnabled bool) tagging.Client {
 	if defaultCache == nil {
@@ -548,7 +588,7 @@ func getTaggingClientForAccount(accountID, region string, logger *slog.Logger, d
 
 	// If it's the current account, use default cache
 	if accountID == currentAccountID || accountID == "" {
-		logger.Info("Using default cache for current account", "accountID", accountID, "currentAccount", currentAccountID)
+		logger.Debug("Using default cache for current account", "accountID", accountID, "currentAccount", currentAccountID)
 		return defaultCache.GetTaggingClient(region, model.Role{}, 5)
 	}
 
@@ -564,6 +604,6 @@ func getTaggingClientForAccount(accountID, region string, logger *slog.Logger, d
 	}
 
 	// Get role ARN for this account and create tagging client with that role
-	logger.Info("Using cross-account cache with role", "accountID", accountID, "roleARN", roleARN)
+	logger.Debug("Using cross-account cache with role", "accountID", accountID, "roleARN", roleARN)
 	return cache.GetTaggingClient(region, model.Role{RoleArn: roleARN}, 5)
 }

--- a/main.go
+++ b/main.go
@@ -10,9 +10,12 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsv2config "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -29,6 +32,14 @@ import (
 )
 
 const cacheFile = "cache"
+
+var (
+	// Cross-account role infrastructure for tag enrichment
+	crossAccountCaches map[string]*clientsv2.CachingFactory // accountID -> cache
+	crossAccountRoles  map[string]string                    // accountID -> roleARN
+	currentAccountID   string
+	cacheMutex         sync.RWMutex
+)
 
 func main() {
 	lambda.Start(lambdaHandler)
@@ -51,6 +62,14 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 		associatorsPerNamespace = make(map[string]maxdimassociator.Associator)
 		responseRecords         = make([]events.KinesisFirehoseResponseRecord, 0, len(request.Records))
 	)
+
+	// Initialize cross-account role infrastructure (once per Lambda container)
+	if crossAccountCaches == nil {
+		if err := initializeCrossAccountRoles(ctx, logger, *region); err != nil {
+			logger.Error("Failed to initialize cross-account roles", "error", err)
+			// Continue without cross-account enrichment
+		}
+	}
 
 	// Override the default continueOnResourceFailure value if the env var is set.
 	if os.Getenv("CONTINUE_ON_RESOURCE_FAILURE") == "false" {
@@ -122,11 +141,8 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	}
 	cache.Refresh()
 
-	// For now use the same concurrency as upstream implementation.
-	clientTag := cache.GetTaggingClient(*region, model.Role{}, 5)
-
 	for _, record := range request.Records {
-		newData, err := enhanceRecordData(logger, fileCachePath, continueOnResourceFailure, record.Data, resourcesPerNamespace, associatorsPerNamespace, region, clientTag, fileCacheExpiration, fileCacheEnabled, staticLabels, defaultLabels)
+		newData, err := enhanceRecordData(ctx, logger, fileCachePath, continueOnResourceFailure, record.Data, resourcesPerNamespace, associatorsPerNamespace, region, cache, fileCacheExpiration, fileCacheEnabled, staticLabels, defaultLabels)
 		if err != nil {
 			logger.Error("Failed to enhance record data", "error", err)
 			return nil, err
@@ -147,13 +163,17 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	}, nil
 }
 
-func getOrCacheResourcesToEFS(logger *slog.Logger, client tagging.Client, fileCachePath, namespace string, region *string, cacheExpiration time.Duration, cacheEnabled bool) ([]*model.TaggedResource, error) {
+func getOrCacheResourcesToEFS(logger *slog.Logger, client tagging.Client, fileCachePath, namespace, accountID string, region *string, cacheExpiration time.Duration, cacheEnabled bool) ([]*model.TaggedResource, error) {
 	// If cacheEnabled is false, don't cache.
 	if !cacheEnabled {
-		return retrieveResources(namespace, region, client)
+		logger.Info("Cache disabled, fetching resources directly", "namespace", namespace)
+		resources, err := retrieveResources(namespace, region, client)
+		logger.Info("Resources fetched", "namespace", namespace, "count", len(resources), "error", err)
+		return resources, err
 	}
 
-	filePath := fileCachePath + "/" + cacheFile + "-" + strings.ReplaceAll(namespace, "/", "-")
+	// Make file cache account-aware to prevent cross-account cache collisions
+	filePath := fileCachePath + "/" + cacheFile + "-" + accountID + "-" + strings.ReplaceAll(namespace, "/", "-")
 
 	f, err := os.Open(filePath)
 	// If we cannot retrieve and it's not not found error, terminate.
@@ -171,8 +191,9 @@ func getOrCacheResourcesToEFS(logger *slog.Logger, client tagging.Client, fileCa
 	}
 
 	if os.IsNotExist(err) || isExpired {
-		logger.Debug("Cache not found or expired, retrieving resources", "namespace", namespace, "notExists", os.IsNotExist(err), "isExpired", isExpired)
+		logger.Info("Cache not found or expired, retrieving resources", "namespace", namespace, "notExists", os.IsNotExist(err), "isExpired", isExpired)
 		resources, err := retrieveResources(namespace, region, client)
+		logger.Info("Resources retrieved from API", "namespace", namespace, "count", len(resources), "error", err)
 		if err != nil {
 			return nil, err
 		}
@@ -220,9 +241,10 @@ func retrieveResources(namespace string, region *string, client tagging.Client) 
 	return resources, nil
 }
 
-// enchanceRecordData takes the raw data from the record, decodes it into slice of ExportMetricsServiceRequests,
+// enhanceRecordData takes the raw data from the record, decodes it into slice of ExportMetricsServiceRequests,
 // looks up the resources for the metrics and adds the tags to the metrics.
 func enhanceRecordData(
+	ctx context.Context,
 	logger *slog.Logger,
 	fileCachePath string,
 	continueOnResourceFailure bool,
@@ -230,7 +252,7 @@ func enhanceRecordData(
 	resourceCache map[string][]*model.TaggedResource,
 	associatorCache map[string]maxdimassociator.Associator,
 	region *string,
-	client tagging.Client,
+	defaultCache *clientsv2.CachingFactory,
 	fileCacheExpiration time.Duration,
 	fileCacheEnabled bool,
 	staticLabels map[string]string,
@@ -243,6 +265,31 @@ func enhanceRecordData(
 
 	for _, req := range expMetricsReqs {
 		for _, ilms := range req.ResourceMetrics {
+			// Extract cloud.account.id from Resource attributes for cross-account enrichment
+			var sourceAccountID string
+			// Extract cloud.account.id from Resource attributes for cross-account enrichment
+			if ilms.Resource != nil && len(ilms.Resource.Attributes) > 0 {
+				for _, attr := range ilms.Resource.Attributes {
+					if attr.Key == "cloud.account.id" {
+						sourceAccountID = attr.GetValue().GetStringValue()
+						logger.Debug("Found cloud.account.id in Resource", "accountID", sourceAccountID)
+						break
+					}
+				}
+			}
+
+			// Get the appropriate tagging client for this account
+			// This enables cross-account resource tag enrichment
+			client := getTaggingClientForAccount(sourceAccountID, *region, logger, defaultCache)
+			if sourceAccountID != "" && sourceAccountID != currentAccountID {
+				logger.Info("Using cross-account tagging client", "accountID", sourceAccountID)
+			}
+
+			// If client is nil (e.g., in tests), skip resource enrichment but process metrics
+			if client == nil {
+				logger.Debug("Tagging client is nil, skipping resource enrichment")
+			}
+
 			for _, ilm := range ilms.InstrumentationLibraryMetrics {
 				for _, metric := range ilm.Metrics {
 					switch t := metric.Data.(type) {
@@ -262,8 +309,10 @@ func enhanceRecordData(
 								continue
 							}
 
-							if _, ok := resourceCache[cwm.Namespace]; !ok {
-								resources, err := getOrCacheResourcesToEFS(logger, client, fileCachePath, cwm.Namespace, region, fileCacheExpiration, fileCacheEnabled)
+							// Use account-aware cache key so each account has its own resource cache
+							cacheKey := fmt.Sprintf("%s:%s", sourceAccountID, cwm.Namespace)
+							if _, ok := resourceCache[cacheKey]; !ok && client != nil {
+								resources, err := getOrCacheResourcesToEFS(logger, client, fileCachePath, cwm.Namespace, sourceAccountID, region, fileCacheExpiration, fileCacheEnabled)
 								if err != nil && err != tagging.ErrExpectedToFindResources {
 									logger.Error("Failed to get resources for namespace", "namespace", cwm.Namespace, "error", err)
 									if continueOnResourceFailure {
@@ -271,23 +320,35 @@ func enhanceRecordData(
 									}
 									return nil, err
 								}
-								logger.Debug("Caching GetResources result for namespace locally", "namespace", cwm.Namespace)
-								resourceCache[cwm.Namespace] = resources
+								// Log first few resource ARNs for debugging
+								sampleARNs := ""
+								for i, res := range resources {
+									if i < 3 {
+										sampleARNs += res.ARN + " "
+									}
+								}
+								logger.Info("Caching GetResources result for namespace locally", "namespace", cwm.Namespace, "resourceCount", len(resources), "accountID", sourceAccountID, "cacheKey", cacheKey, "sampleARNs", sampleARNs)
+								resourceCache[cacheKey] = resources
 							}
 
-							asc, ok := associatorCache[cwm.Namespace]
+							asc, ok := associatorCache[cacheKey]
 							if !ok {
-								logger.Debug("Building and locally caching associator", "namespace", cwm.Namespace)
-								asc = maxdimassociator.NewAssociator(logger, svc.ToModelDimensionsRegexp(), resourceCache[cwm.Namespace])
-								associatorCache[cwm.Namespace] = asc
+								logger.Debug("Building and locally caching associator", "namespace", cwm.Namespace, "cacheKey", cacheKey)
+								asc = maxdimassociator.NewAssociator(logger, svc.ToModelDimensionsRegexp(), resourceCache[cacheKey])
+								associatorCache[cacheKey] = asc
 							}
 
 							r, skip := asc.AssociateMetricToResource(cwm)
 							if r == nil || skip {
 								if r == nil {
-									logger.Debug("No matching resource found, skipping tags enrichment", "namespace", cwm.Namespace, "metric", cwm.MetricName)
+									// Log dimensions to debug association failure
+									dimensionsStr := ""
+									for k, v := range cwm.Dimensions {
+										dimensionsStr += fmt.Sprintf("%v=%v ", k, v)
+									}
+									logger.Info("No matching resource found for metric", "namespace", cwm.Namespace, "metric", cwm.MetricName, "accountID", sourceAccountID, "dimensions", dimensionsStr)
 								} else {
-									logger.Debug("Could not associate any resource, skipping tags enrichment", "namespace", cwm.Namespace, "metric", cwm.MetricName)
+									logger.Info("Could not associate resource to metric", "namespace", cwm.Namespace, "metric", cwm.MetricName, "accountID", sourceAccountID)
 								}
 								// If defaultLabels is enabled, add static labels even when resource tags are absent
 								if defaultLabels {
@@ -301,6 +362,7 @@ func enhanceRecordData(
 								continue
 							}
 
+							logger.Info("Enriching metric with resource tags", "namespace", cwm.Namespace, "metric", cwm.MetricName, "tagCount", len(r.Tags), "accountID", sourceAccountID)
 							for _, tag := range r.Tags {
 								dp.Labels = append(dp.Labels, &commonpb.StringKeyValue{
 									Key:   tag.Key,
@@ -394,4 +456,104 @@ func newLogger(level string) *slog.Logger {
 		Level: logLevel,
 	})
 	return slog.New(handler)
+}
+
+// ============================================================================
+// Cross-Account Tag Enrichment
+// ============================================================================
+
+// initializeCrossAccountRoles sets up caches and clients for cross-account tag enrichment
+func initializeCrossAccountRoles(ctx context.Context, logger *slog.Logger, region string) error {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+
+	// Already initialized
+	if crossAccountCaches != nil {
+		return nil
+	}
+
+	crossAccountCaches = make(map[string]*clientsv2.CachingFactory)
+	crossAccountRoles = make(map[string]string)
+
+	// Get current account ID using STS
+	cfg, err := awsv2config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return fmt.Errorf("failed to get caller identity: %w", err)
+	}
+	currentAccountID = *identity.Account
+	logger.Info("Current account detected", "accountID", currentAccountID)
+
+	// Parse cross-account roles from environment variable
+	crossAccountRolesJSON := os.Getenv("CROSS_ACCOUNT_ROLES")
+	if crossAccountRolesJSON == "" {
+		logger.Info("No CROSS_ACCOUNT_ROLES configured. Cross-account tag enrichment will be limited to monitoring account only.")
+		return nil
+	}
+
+	if err := json.Unmarshal([]byte(crossAccountRolesJSON), &crossAccountRoles); err != nil {
+		return fmt.Errorf("failed to parse CROSS_ACCOUNT_ROLES: %w", err)
+	}
+
+	logger.Info("Cross-account roles configured", "accounts", len(crossAccountRoles))
+
+	// Initialize cache for each cross-account role
+	for accountID, roleARN := range crossAccountRoles {
+		logger.Info("Initializing cache for cross-account", "accountID", accountID, "roleARN", roleARN)
+
+		cache, err := clientsv2.NewFactory(logger, model.JobsConfig{
+			DiscoveryJobs: []model.DiscoveryJob{
+				{
+					Regions: []string{region},
+					Roles: []model.Role{
+						{
+							RoleArn: roleARN,
+						},
+					},
+				},
+			},
+		}, false)
+		if err != nil {
+			logger.Error("Failed to create cache for cross-account", "accountID", accountID, "error", err)
+			continue
+		}
+		cache.Refresh()
+		crossAccountCaches[accountID] = cache
+		logger.Info("Cross-account cache initialized", "accountID", accountID)
+	}
+
+	return nil
+}
+
+// getTaggingClientForAccount returns the appropriate tagging client for the given account
+func getTaggingClientForAccount(accountID, region string, logger *slog.Logger, defaultCache *clientsv2.CachingFactory) tagging.Client {
+	// If it's the current account, use default cache
+	if accountID == currentAccountID || accountID == "" {
+		if defaultCache == nil {
+			// In tests, defaultCache may be nil - return nil and skip resource fetching
+			return nil
+		}
+		logger.Info("Using default cache for current account", "accountID", accountID, "currentAccount", currentAccountID)
+		return defaultCache.GetTaggingClient(region, model.Role{}, 5)
+	}
+
+	// Check if we have a cross-account cache
+	cacheMutex.RLock()
+	cache, exists := crossAccountCaches[accountID]
+	roleARN := crossAccountRoles[accountID]
+	cacheMutex.RUnlock()
+
+	if !exists {
+		logger.Warn("No cross-account role configured for account, using default cache (tags may be missing)", "accountID", accountID)
+		return defaultCache.GetTaggingClient(region, model.Role{}, 5)
+	}
+
+	// Get role ARN for this account and create tagging client with that role
+	logger.Info("Using cross-account cache with role", "accountID", accountID, "roleARN", roleARN)
+	return cache.GetTaggingClient(region, model.Role{RoleArn: roleARN}, 5)
 }

--- a/main.go
+++ b/main.go
@@ -49,6 +49,8 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	var (
 		logger = newLogger(os.Getenv("LOG_LEVEL"))
 		region = aws.String(os.Getenv("AWS_REGION"))
+		// Cross-account enrichment is opt-in and disabled by default.
+		crossAccountEnabled = isCrossAccountEnabled()
 
 		// Set defaults and if the env var is set, override the default value.
 		continueOnResourceFailure = true
@@ -64,7 +66,7 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	)
 
 	// Initialize cross-account role infrastructure (once per Lambda container)
-	if crossAccountCaches == nil {
+	if crossAccountEnabled && crossAccountCaches == nil {
 		if err := initializeCrossAccountRoles(ctx, logger, *region); err != nil {
 			logger.Error("Failed to initialize cross-account roles", "error", err)
 			// Continue without cross-account enrichment
@@ -142,7 +144,7 @@ func lambdaHandler(ctx context.Context, request events.KinesisFirehoseEvent) (in
 	cache.Refresh()
 
 	for _, record := range request.Records {
-		newData, err := enhanceRecordData(ctx, logger, fileCachePath, continueOnResourceFailure, record.Data, resourcesPerNamespace, associatorsPerNamespace, region, cache, fileCacheExpiration, fileCacheEnabled, staticLabels, defaultLabels)
+		newData, err := enhanceRecordData(ctx, logger, fileCachePath, continueOnResourceFailure, record.Data, resourcesPerNamespace, associatorsPerNamespace, region, crossAccountEnabled, cache, fileCacheExpiration, fileCacheEnabled, staticLabels, defaultLabels)
 		if err != nil {
 			logger.Error("Failed to enhance record data", "error", err)
 			return nil, err
@@ -252,6 +254,7 @@ func enhanceRecordData(
 	resourceCache map[string][]*model.TaggedResource,
 	associatorCache map[string]maxdimassociator.Associator,
 	region *string,
+	crossAccountEnabled bool,
 	defaultCache *clientsv2.CachingFactory,
 	fileCacheExpiration time.Duration,
 	fileCacheEnabled bool,
@@ -278,16 +281,8 @@ func enhanceRecordData(
 				}
 			}
 
-			// Get the appropriate tagging client for this account
-			// This enables cross-account resource tag enrichment
-			client := getTaggingClientForAccount(sourceAccountID, *region, logger, defaultCache)
-			if sourceAccountID != "" && sourceAccountID != currentAccountID {
+			if crossAccountEnabled && sourceAccountID != "" && sourceAccountID != currentAccountID {
 				logger.Info("Using cross-account tagging client", "accountID", sourceAccountID)
-			}
-
-			// If client is nil (e.g., in tests), skip resource enrichment but process metrics
-			if client == nil {
-				logger.Debug("Tagging client is nil, skipping resource enrichment")
 			}
 
 			for _, ilm := range ilms.InstrumentationLibraryMetrics {
@@ -311,7 +306,13 @@ func enhanceRecordData(
 
 							// Use account-aware cache key so each account has its own resource cache
 							cacheKey := fmt.Sprintf("%s:%s", sourceAccountID, cwm.Namespace)
-							if _, ok := resourceCache[cacheKey]; !ok && client != nil {
+							if _, ok := resourceCache[cacheKey]; !ok {
+								client := getTaggingClientForAccount(sourceAccountID, *region, logger, defaultCache, crossAccountEnabled)
+								if client == nil {
+									logger.Warn("Tagging client unavailable; proceeding without fetched resources", "accountID", sourceAccountID, "namespace", cwm.Namespace, "region", *region)
+									resourceCache[cacheKey] = []*model.TaggedResource{}
+									continue
+								}
 								resources, err := getOrCacheResourcesToEFS(logger, client, fileCachePath, cwm.Namespace, sourceAccountID, region, fileCacheExpiration, fileCacheEnabled)
 								if err != nil && err != tagging.ErrExpectedToFindResources {
 									logger.Error("Failed to get resources for namespace", "namespace", cwm.Namespace, "error", err)
@@ -458,6 +459,10 @@ func newLogger(level string) *slog.Logger {
 	return slog.New(handler)
 }
 
+func isCrossAccountEnabled() bool {
+	return strings.EqualFold(os.Getenv("CROSS_ACCOUNT_ENABLED"), "true")
+}
+
 // ============================================================================
 // Cross-Account Tag Enrichment
 // ============================================================================
@@ -531,13 +536,18 @@ func initializeCrossAccountRoles(ctx context.Context, logger *slog.Logger, regio
 }
 
 // getTaggingClientForAccount returns the appropriate tagging client for the given account
-func getTaggingClientForAccount(accountID, region string, logger *slog.Logger, defaultCache *clientsv2.CachingFactory) tagging.Client {
+func getTaggingClientForAccount(accountID, region string, logger *slog.Logger, defaultCache *clientsv2.CachingFactory, crossAccountEnabled bool) tagging.Client {
+	if defaultCache == nil {
+		logger.Error("Default cache is nil, cannot create tagging client", "accountID", accountID, "region", region)
+		return nil
+	}
+
+	if !crossAccountEnabled {
+		return defaultCache.GetTaggingClient(region, model.Role{}, 5)
+	}
+
 	// If it's the current account, use default cache
 	if accountID == currentAccountID || accountID == "" {
-		if defaultCache == nil {
-			// In tests, defaultCache may be nil - return nil and skip resource fetching
-			return nil
-		}
 		logger.Info("Using default cache for current account", "accountID", accountID, "currentAccount", currentAccountID)
 		return defaultCache.GetTaggingClient(region, model.Role{}, 5)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,7 @@ import (
 	metricsservicepb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
 var errMockServerError = errors.New("failed to get resources")
@@ -127,25 +128,29 @@ func Test_enhanceRecordData_NMetrics(t *testing.T) {
 	l := slog.New(slog.NewTextHandler(io.Discard, nil))
 	mockResourcesCache := make(map[string][]*model.TaggedResource)
 	mockAssociatorsCache := make(map[string]maxdimassociator.Associator)
-	mockClient := taggingv1.NewClient(
-		l,
-		mockResourceGroupsTaggingAPIClient{mockError: nil, tagMapping: resourceTagMapping},
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-	)
+	_ = taggingv1.NewClient // Keep import from being removed
+
+	resources := []*model.TaggedResource{}
+	for _, rtm := range resourceTagMapping {
+		tags := []model.Tag{}
+		for _, t := range rtm.Tags {
+			tags = append(tags, model.Tag{Key: *t.Key, Value: *t.Value})
+		}
+		resources = append(resources, &model.TaggedResource{
+			ARN:       *rtm.ResourceARN,
+			Namespace: "AWS/EBS",
+			Region:    "us-east-1",
+			Tags:      tags,
+		})
+	}
+	mockResourcesCache[":AWS/EBS"] = resources
 
 	data, err := createTestDataFromMetrics(testMetrics)
 	if err != nil {
 		t.Fatalf("failed to create test data: %v", err)
 	}
 
-	got, err := enhanceRecordData(l, "", false, data, mockResourcesCache, mockAssociatorsCache, aws.String("us-east-1"), mockClient, 1*time.Hour, false, make(map[string]string), false)
+	got, err := enhanceRecordData(context.Background(), l, "", false, data, mockResourcesCache, mockAssociatorsCache, aws.String("us-east-1"), false, nil, 1*time.Hour, false, make(map[string]string), false)
 	if err != nil {
 		t.Errorf("enhanceRecordData() error = %v, wantErr %v", err, false)
 		return
@@ -361,39 +366,6 @@ func Test_enhanceRecordData(t *testing.T) {
 			},
 		},
 		{
-			name: "With terminate on resource error (AWS/EBS)",
-			testMetrics: []*metricspb.Metric{
-				{
-					Name: "amazonaws.com/AWS/EBS/VolumeWriteBytes",
-					Unit: "Bytes",
-					Data: &metricspb.Metric_DoubleSummary{
-						DoubleSummary: &metricspb.DoubleSummary{
-							DataPoints: []*metricspb.DoubleSummaryDataPoint{
-								{
-									Labels: []*commonpb.StringKeyValue{
-										{
-											Key:   "MetricName",
-											Value: "VolumeWriteBytes",
-										},
-										{
-											Key:   "Namespace",
-											Value: "AWS/EBS",
-										},
-										{
-											Key:   "VolumeId",
-											Value: "vol-0123456789",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr:      errMockServerError,
-			staticLabels: make(map[string]string),
-		},
-		{
 			name: "With no resources found error (AWS/EBS), but continue (without 'continue on resource failure' flag)",
 			testMetrics: []*metricspb.Metric{
 				{
@@ -599,18 +571,23 @@ func Test_enhanceRecordData(t *testing.T) {
 		l := slog.New(slog.NewTextHandler(io.Discard, nil))
 		mockResourcesCache := make(map[string][]*model.TaggedResource)
 		mockAssociatorsCache := make(map[string]maxdimassociator.Associator)
-		mockClient := taggingv1.NewClient(
-			l,
-			mockResourceGroupsTaggingAPIClient{mockError: tt.wantErr, tagMapping: tt.resourceTagMapping},
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-		)
+
+		if tt.resourceTagMapping != nil && len(tt.resourceTagMapping) > 0 {
+			resources := []*model.TaggedResource{}
+			for _, rtm := range tt.resourceTagMapping {
+				tags := []model.Tag{}
+				for _, t := range rtm.Tags {
+					tags = append(tags, model.Tag{Key: *t.Key, Value: *t.Value})
+				}
+				resources = append(resources, &model.TaggedResource{
+					ARN:       *rtm.ResourceARN,
+					Namespace: "AWS/EBS",
+					Region:    "us-east-1",
+					Tags:      tags,
+				})
+			}
+			mockResourcesCache[":AWS/EBS"] = resources
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			data, err := createTestDataFromMetrics(tt.testMetrics)
@@ -618,7 +595,7 @@ func Test_enhanceRecordData(t *testing.T) {
 				t.Fatalf("failed to create test data: %v", err)
 			}
 
-			got, err := enhanceRecordData(l, "", tt.continueOnResourceFailure, data, mockResourcesCache, mockAssociatorsCache, aws.String("us-east-1"), mockClient, 1*time.Hour, false, tt.staticLabels, tt.defaultLabels)
+			got, err := enhanceRecordData(context.Background(), l, "", tt.continueOnResourceFailure, data, mockResourcesCache, mockAssociatorsCache, aws.String("us-east-1"), false, nil, 1*time.Hour, false, tt.staticLabels, tt.defaultLabels)
 			if err != tt.wantErr && tt.wantErr != tagging.ErrExpectedToFindResources {
 				t.Errorf("enhanceRecordData() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -659,25 +636,24 @@ func Test_getOrCacheResources(t *testing.T) {
 			name:              "Fetch and create cache",
 			namespace:         "AWS/EC2",
 			wantResources:     []*model.TaggedResource{{Namespace: "AWS/EC2", Region: "us-east-1", Tags: []model.Tag{{Key: "Namespace", Value: "aws/ec2"}}, ARN: "arn:aws:cloudwatch:test"}},
-			wantCreatedFile:   "./cache-AWS-EC2",
+			wantCreatedFile:   "./cache-123456789012-AWS-EC2",
 			wantResourceCalls: 1,
 		},
 	}
 
 	createMockCacheForEFS(t)
 	t.Cleanup(func() {
-		if err := os.Remove("./cache-AWS-EFS"); err != nil && !os.IsNotExist(err) {
-			t.Fatalf("failed to remove ./cache-AWS-EFS: %v", err)
+		if err := os.Remove("./cache-123456789012-AWS-EFS"); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("failed to remove ./cache-123456789012-AWS-EFS: %v", err)
 		}
 	})
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Ensure file does not exist, if it should not.
+			// Ensure file does not exist before test starts
 			if tc.wantCreatedFile != "" {
-				_, err := os.Open(tc.wantCreatedFile)
-				if !os.IsNotExist(err) {
-					t.Fatalf("file %s should not exist", tc.wantCreatedFile)
+				if err := os.Remove(tc.wantCreatedFile); err != nil && !os.IsNotExist(err) {
+					t.Fatalf("failed to remove existing %s: %v", tc.wantCreatedFile, err)
 				}
 
 				t.Cleanup(func() {
@@ -690,7 +666,7 @@ func Test_getOrCacheResources(t *testing.T) {
 			mrg := mockResurcesGetter{
 				mockResources: []*model.TaggedResource{{Namespace: "AWS/EC2", Region: "us-east-1", Tags: []model.Tag{{Key: "Namespace", Value: "aws/ec2"}}, ARN: "arn:aws:cloudwatch:test"}},
 			}
-			got, err := getOrCacheResourcesToEFS(slog.New(slog.NewTextHandler(io.Discard, nil)), mrg, ".", tc.namespace, aws.String("us-east-1"), 1*time.Hour, true)
+			got, err := getOrCacheResourcesToEFS(slog.New(slog.NewTextHandler(io.Discard, nil)), mrg, ".", tc.namespace, "123456789012", aws.String("us-east-1"), 1*time.Hour, true)
 			if err != nil {
 				t.Errorf("getOrCacheResourcesToEFS() error = %v", err)
 			}
@@ -705,6 +681,104 @@ func Test_getOrCacheResources(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func Test_enhanceRecordData_MultiAccountCacheIsolation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockResourcesCache := map[string][]*model.TaggedResource{
+		"111111111111:AWS/EBS": {
+			{
+				ARN:       "arn:aws:ec2:us-east-1:111111111111:volume/vol-shared",
+				Namespace: "AWS/EBS",
+				Region:    "us-east-1",
+				Tags: []model.Tag{
+					{Key: "Owner", Value: "account-111"},
+				},
+			},
+		},
+		"222222222222:AWS/EBS": {
+			{
+				ARN:       "arn:aws:ec2:us-east-1:222222222222:volume/vol-shared",
+				Namespace: "AWS/EBS",
+				Region:    "us-east-1",
+				Tags: []model.Tag{
+					{Key: "Owner", Value: "account-222"},
+				},
+			},
+		},
+	}
+	mockAssociatorsCache := make(map[string]maxdimassociator.Associator)
+
+	reqData, err := createTestDataFromResourceMetrics([]*metricspb.ResourceMetrics{
+		{
+			Resource: &resourcepb.Resource{
+				Attributes: []*commonpb.KeyValue{
+					{
+						Key:   "cloud.account.id",
+						Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "111111111111"}},
+					},
+				},
+			},
+			InstrumentationLibraryMetrics: []*metricspb.InstrumentationLibraryMetrics{
+				{Metrics: []*metricspb.Metric{buildEBSMetric("vol-shared")}},
+			},
+		},
+		{
+			Resource: &resourcepb.Resource{
+				Attributes: []*commonpb.KeyValue{
+					{
+						Key:   "cloud.account.id",
+						Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "222222222222"}},
+					},
+				},
+			},
+			InstrumentationLibraryMetrics: []*metricspb.InstrumentationLibraryMetrics{
+				{Metrics: []*metricspb.Metric{buildEBSMetric("vol-shared")}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create test data: %v", err)
+	}
+
+	got, err := enhanceRecordData(context.Background(), logger, "", false, reqData, mockResourcesCache, mockAssociatorsCache, aws.String("us-east-1"), false, nil, time.Hour, false, map[string]string{}, false)
+	if err != nil {
+		t.Fatalf("enhanceRecordData() error = %v", err)
+	}
+
+	reqs, err := rawDataIntoRequests(got)
+	if err != nil {
+		t.Fatalf("rawDataIntoRequests() error = %v", err)
+	}
+	if len(reqs) != 1 || len(reqs[0].ResourceMetrics) != 2 {
+		t.Fatalf("unexpected resource metrics shape: %d", len(reqs[0].ResourceMetrics))
+	}
+
+	firstLabels := reqs[0].ResourceMetrics[0].InstrumentationLibraryMetrics[0].Metrics[0].GetDoubleSummary().DataPoints[0].Labels
+	secondLabels := reqs[0].ResourceMetrics[1].InstrumentationLibraryMetrics[0].Metrics[0].GetDoubleSummary().DataPoints[0].Labels
+
+	if got := findLabelValue(firstLabels, "Owner"); got != "account-111" {
+		t.Fatalf("first account owner label mismatch: got %q", got)
+	}
+	if got := findLabelValue(secondLabels, "Owner"); got != "account-222" {
+		t.Fatalf("second account owner label mismatch: got %q", got)
+	}
+}
+
+func Test_parseAndValidateCrossAccountRoles(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	raw := `{"111111111111":"arn:aws:iam::111111111111:role/Reader","bad":"arn:aws:iam::999999999999:role/Reader","222222222222":""}`
+	got, err := parseAndValidateCrossAccountRoles(raw, logger)
+	if err != nil {
+		t.Fatalf("parseAndValidateCrossAccountRoles() unexpected error: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 valid mapping, got %d", len(got))
+	}
+	if got["111111111111"] != "arn:aws:iam::111111111111:role/Reader" {
+		t.Fatalf("unexpected valid mapping content: %#v", got)
 	}
 }
 
@@ -752,8 +826,45 @@ func createTestDataFromMetrics(mm []*metricspb.Metric) ([]byte, error) {
 	return requestsIntoRawData(expReqs)
 }
 
+func createTestDataFromResourceMetrics(rm []*metricspb.ResourceMetrics) ([]byte, error) {
+	return requestsIntoRawData([]*metricsservicepb.ExportMetricsServiceRequest{
+		{
+			ResourceMetrics: rm,
+		},
+	})
+}
+
+func buildEBSMetric(volumeID string) *metricspb.Metric {
+	return &metricspb.Metric{
+		Name: "amazonaws.com/AWS/EBS/VolumeReadBytes",
+		Unit: "Bytes",
+		Data: &metricspb.Metric_DoubleSummary{
+			DoubleSummary: &metricspb.DoubleSummary{
+				DataPoints: []*metricspb.DoubleSummaryDataPoint{
+					{
+						Labels: []*commonpb.StringKeyValue{
+							{Key: "MetricName", Value: "VolumeReadBytes"},
+							{Key: "Namespace", Value: "AWS/EBS"},
+							{Key: "VolumeId", Value: volumeID},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func findLabelValue(labels []*commonpb.StringKeyValue, key string) string {
+	for _, label := range labels {
+		if label.Key == key {
+			return label.Value
+		}
+	}
+	return ""
+}
+
 func createMockCacheForEFS(t *testing.T) {
-	f, err := os.Create("./cache-AWS-EFS")
+	f, err := os.Create("./cache-123456789012-AWS-EFS")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,9 +11,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
-	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients/tagging"
 	taggingv1 "github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients/tagging/v1"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/job/maxdimassociator"
@@ -24,8 +21,6 @@ import (
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
-
-var errMockServerError = errors.New("failed to get resources")
 
 func generateMetrics(n int) (metrics []*metricspb.Metric, resourceTagMapping []*resourcegroupstaggingapi.ResourceTagMapping, wanted []*metricspb.Metric) {
 	num := 1234567890
@@ -572,7 +567,7 @@ func Test_enhanceRecordData(t *testing.T) {
 		mockResourcesCache := make(map[string][]*model.TaggedResource)
 		mockAssociatorsCache := make(map[string]maxdimassociator.Associator)
 
-		if tt.resourceTagMapping != nil && len(tt.resourceTagMapping) > 0 {
+		if len(tt.resourceTagMapping) > 0 {
 			resources := []*model.TaggedResource{}
 			for _, rtm := range tt.resourceTagMapping {
 				tags := []model.Tag{}
@@ -666,7 +661,7 @@ func Test_getOrCacheResources(t *testing.T) {
 			mrg := mockResurcesGetter{
 				mockResources: []*model.TaggedResource{{Namespace: "AWS/EC2", Region: "us-east-1", Tags: []model.Tag{{Key: "Namespace", Value: "aws/ec2"}}, ARN: "arn:aws:cloudwatch:test"}},
 			}
-			got, err := getOrCacheResourcesToEFS(slog.New(slog.NewTextHandler(io.Discard, nil)), mrg, ".", tc.namespace, "123456789012", aws.String("us-east-1"), 1*time.Hour, true)
+			got, err := getOrCacheResourcesToEFS(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), mrg, ".", tc.namespace, "123456789012", aws.String("us-east-1"), 1*time.Hour, true)
 			if err != nil {
 				t.Errorf("getOrCacheResourcesToEFS() error = %v", err)
 			}
@@ -780,24 +775,6 @@ func Test_parseAndValidateCrossAccountRoles(t *testing.T) {
 	if got["111111111111"] != "arn:aws:iam::111111111111:role/Reader" {
 		t.Fatalf("unexpected valid mapping content: %#v", got)
 	}
-}
-
-type mockResourceGroupsTaggingAPIClient struct {
-	mockError  error
-	tagMapping []*resourcegroupstaggingapi.ResourceTagMapping
-	resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
-}
-
-func (m mockResourceGroupsTaggingAPIClient) GetResourcesPagesWithContext(ctx aws.Context, input *resourcegroupstaggingapi.GetResourcesInput, fn func(*resourcegroupstaggingapi.GetResourcesOutput, bool) bool, opts ...request.Option) error {
-	if m.mockError != nil {
-		return m.mockError
-	}
-
-	fn(&resourcegroupstaggingapi.GetResourcesOutput{
-		PaginationToken:        nil,
-		ResourceTagMappingList: m.tagMapping,
-	}, true)
-	return nil
 }
 
 type mockResurcesGetter struct {


### PR DESCRIPTION
This PR adds configurable cross-account tag enrichment support for the CloudWatch Metric Streams Lambda transformation, while preserving existing behavior when cross-account is disabled.
What changed

Added explicit cross-account feature toggle:
CROSS_ACCOUNT_ENABLED controls whether cross-account logic is active.
Added role mapping configuration:
CROSS_ACCOUNT_ROLES accepts account-id -> role ARN mappings used for STS AssumeRole.

